### PR TITLE
Preserve new lines

### DIFF
--- a/notes-import.scpt
+++ b/notes-import.scpt
@@ -35,7 +35,7 @@ folderContents.forEach(function(item)
 	{
 		var note = notesApp.Note({
 			'name': item,
-			'body': fileContents
+			'body': fileContents.replace(/\n/g,'<br>')
 		})
 
 		notesApp.folders[0].notes.push(note)


### PR DESCRIPTION
By default, new lines get chewed up by Notes.app, but converting them to `<br>` tags works

Tested on 10.11.0
