### PR TITLE
Remove extension from note name

### DIFF
--- a/notes-import.scpt
+++ b/notes-import.scpt
@@ -35,7 +35,7 @@ folderContents.forEach(function(item)
 	if ( fileContents !== false )
 	{
 		var note = notesApp.Note({
-			'name': item,
+			'name': item.replace(/\.\w{3,4}$/, ''),
 			'body': fileContents
 		})
 


### PR DESCRIPTION
Added a regex replace to remove the extension from the note name.
