### PR TITLE
Provide user with choice of Notes account and folder

### DIFF
--- a/notes-import.scpt
+++ b/notes-import.scpt
@@ -28,6 +28,8 @@ var folderName = notesApp.chooseFolder()
 
 var folderContents = Application('System Events').folders.byName(folderName.toString()).diskItems.name()
 
+var notesFolder = getNotesFolder();
+
 folderContents.forEach(function(item) 
 {
 	var fileContents = fileContentsAtPath(folderName + '/' + item)
@@ -39,7 +41,7 @@ folderContents.forEach(function(item)
 			'body': fileContents
 		})
 
-		notesApp.folders[0].notes.push(note)
+		notesFolder.notes.push(note) 
 	}
 })
 
@@ -79,4 +81,54 @@ function fileContentsAtPath(pathAsString)
 	}
 	
 	return data;
+}
+
+// Prompt user to pick a folder from chosen account if more than one
+
+function getNotesFolder()
+{
+	var folderChoice;
+	var acct = getNotesAccount();
+	var folders = [];
+	var msg = 'Which folder in ' + acct.name() + '?';
+	
+	if (acct.folders.length === 1) {
+		return acct.folders[0];
+	}
+	
+	for (var e in acct.folders) {
+		folders.push(acct.folders[e].name())
+	}
+	
+	folderChoice = notesApp.chooseFromList(folders, {
+		withTitle: 'Folder for import',
+		withPrompt: msg
+	});
+	
+
+	return acct.folders[ folderChoice[0] ];
+}
+
+// Prompt user to pick an account in Notes app if more than one
+function getNotesAccount()
+{
+	var acctChoice, acct;
+	var options = [];
+	var accts = notesApp.accounts;
+
+	if (accts.length === 1)
+	{
+		return notesApp
+	}
+
+		for (var e in accts)  {
+			options.push(accts[e].name());
+		}
+	
+		acctChoice = notesApp.chooseFromList(options, {
+			withTitle: 'Notes Account',
+			withPrompt: 'Which account do you want to use to import your notes?'
+		});
+
+		return notesApp.accounts[ acctChoice[0] ];
 }


### PR DESCRIPTION
This PR adds up to 2 more prompts so users can choose (a) an account in the Notes app and (b) a folder within the chosen account. If only one account exists, skips the prompt; same thing for folder.
